### PR TITLE
docs: add GitHub Copilot Instructions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,19 @@ Useful settings:
 https://code.visualstudio.com/docs/copilot/customization/mcp-servers
 
 An example configuration is available at [`.vscode/mcp.json`](.vscode/mcp.json)
+
+## GitHub Copilot Instructions
+
+This repository includes a [`.github/copilot-instructions.md`](.github/copilot-instructions.md) file that provides custom instructions to GitHub Copilot. This file helps Copilot understand your project's specific conventions, coding standards, and best practices to provide more contextually relevant suggestions.
+
+The instructions file includes guidance on:
+
+- Project overview and technology stack
+- Code style and naming conventions
+- Testing standards and patterns
+- Documentation requirements
+- Git practices and commit message formatting
+- Security and performance considerations
+- Project-specific guidelines and domain logic
+
+GitHub Copilot automatically reads this file when providing suggestions in your repository, ensuring that generated code aligns with your team's standards. You can customize this template to match your project's specific needs.


### PR DESCRIPTION
## Description

This PR adds a new section to the README that documents the `.github/copilot-instructions.md` file and its purpose.

## Changes

- Added a "GitHub Copilot Instructions" section after the Visual Studio Code section
- Explains what the instructions file contains and how it helps Copilot provide better suggestions
- Links to the actual instructions file in the repository

## Why

Users should be aware that this configuration file exists and understand how they can customize it to improve Copilot's suggestions for their specific project needs.

This pull request description was generated by GitHub Copilot :copilot: