### PR TITLE
Add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 A collection of notes and configuration for using [GitHub Copilot](https://github.com/features/copilot) :copilot:
 
+## Table of Contents
+
+- [GitHub Copilot on the web](#github-copilot-on-the-web)
+  - [Chat](#chat)
+  - [Agents](#agents)
+  - [Spaces](#spaces)
+  - [Spark](#spark)
+  - [MCP Registry](#mcp-registry)
+- [GitHub Copilot CLI](#github-copilot-cli)
+- [Visual Studio Code](#visual-studio-code)
+  - [Chat](#chat-1)
+  - [MCP](#mcp)
+- [GitHub Copilot Instructions](#github-copilot-instructions)
+
 ## GitHub Copilot on the web
 
 There are several options available for using GitHub Copilot on the web:

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A collection of notes and configuration for using [GitHub Copilot](https://githu
 ## Table of Contents
 
 - [GitHub Copilot on the web](#github-copilot-on-the-web)
-  - [Chat](#chat)
+  - [Chat on GitHub.com](#chat-on-githubcom)
   - [Agents](#agents)
   - [Spaces](#spaces)
   - [Spark](#spark)
   - [MCP Registry](#mcp-registry)
 - [GitHub Copilot CLI](#github-copilot-cli)
 - [Visual Studio Code](#visual-studio-code)
-  - [Chat](#chat-1)
+  - [Chat in Visual Studio Code](#chat-in-visual-studio-code)
   - [MCP](#mcp)
 - [GitHub Copilot Instructions](#github-copilot-instructions)
 
@@ -22,7 +22,7 @@ A collection of notes and configuration for using [GitHub Copilot](https://githu
 
 There are several options available for using GitHub Copilot on the web:
 
-### Chat
+### Chat on GitHub.com
 
 https://docs.github.com/en/copilot/how-tos/chat-with-copilot/chat-in-github
 
@@ -64,7 +64,7 @@ https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli
 
 https://code.visualstudio.com/docs/copilot/overview
 
-### Chat
+### Chat in Visual Studio Code
 
 https://code.visualstudio.com/docs/copilot/chat/copilot-chat
 


### PR DESCRIPTION
This pull request adds a comprehensive table of contents to the README for easier navigation.

The table of contents includes links to all major sections and subsections:
- GitHub Copilot on the web (with subsections for Chat, Agents, Spaces, Spark, and MCP Registry)
- GitHub Copilot CLI
- Visual Studio Code (with subsections for Chat and MCP)
- GitHub Copilot Instructions

Fixes #6

This pull request description was generated by GitHub Copilot :copilot: